### PR TITLE
feat: Core Navigation MVP — MCP tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
+    "pretest": "tsc",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/src/document-manager.ts
+++ b/src/document-manager.ts
@@ -11,6 +11,7 @@ interface DocumentState {
   version: number;
   content: string;
   isOpen: boolean;
+  connection: ProtocolConnection;
 }
 
 /**
@@ -31,6 +32,13 @@ export class DocumentManager implements DocumentContentProvider {
     content?: string,
   ): Promise<void> {
     const existing = this.documents.get(uri);
+
+    // If the connection changed (e.g. LSP server restarted), the new server
+    // doesn't know about previously opened docs — force a fresh didOpen.
+    if (existing && existing.isOpen && existing.connection !== connection) {
+      this.documents.set(uri, { ...existing, isOpen: false });
+      return this.ensureOpen(uri, connection, content);
+    }
 
     if (!existing || !existing.isOpen) {
       // Need to open the document
@@ -58,6 +66,7 @@ export class DocumentManager implements DocumentContentProvider {
         version,
         content: text,
         isOpen: true,
+        connection,
       });
       return;
     }
@@ -92,6 +101,7 @@ export class DocumentManager implements DocumentContentProvider {
         version: newVersion,
         content: effectiveContent,
         isOpen: true,
+        connection,
       });
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,32 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { WorkspaceManager } from './workspace-manager.js';
+import { DocumentManager } from './document-manager.js';
+import { registerDefinitionTool } from './tools/definition.js';
+import { registerReferencesTool } from './tools/references.js';
+import { registerHoverTool } from './tools/hover.js';
 
 const server = new McpServer({
   name: 'tsmcp-lsp',
   version: '0.1.0',
 });
 
-// TODO: Register MCP tools (ts_definition, ts_references, ts_hover, ts_symbols)
-// Tool registration is deferred to the tools epic; this stub validates the build.
+const workspaceManager = new WorkspaceManager();
+const documentManager = new DocumentManager();
+
+// Register MCP tools
+registerDefinitionTool(server, workspaceManager, documentManager);
+registerReferencesTool(server, workspaceManager, documentManager);
+registerHoverTool(server, workspaceManager, documentManager);
+
+// Graceful shutdown
+async function shutdown() {
+  await workspaceManager.shutdownAll();
+  process.exit(0);
+}
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);
 
 async function main() {
   const transport = new StdioServerTransport();

--- a/src/tools/definition.ts
+++ b/src/tools/definition.ts
@@ -1,0 +1,81 @@
+import path from 'node:path';
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Location, LocationLink } from 'vscode-languageserver-protocol';
+import type { WorkspaceManager } from '../workspace-manager.js';
+import type { DocumentManager } from '../document-manager.js';
+import { pathToUri, uriToPath, toLspPosition, fromLspPosition, getPreviewLine } from '../utils.js';
+
+export function registerDefinitionTool(
+  server: McpServer,
+  workspaceManager: WorkspaceManager,
+  documentManager: DocumentManager,
+): void {
+  server.registerTool(
+    'ts_definition',
+    {
+      description: 'Go to definition of a TypeScript/JavaScript symbol',
+      inputSchema: {
+        file_path: z.string().describe('Absolute path to the file'),
+        line: z.number().describe('Line number (1-indexed)'),
+        column: z.number().describe('Column number (1-indexed)'),
+        content: z.string().optional().describe('Optional file content override'),
+      },
+    },
+    async ({ file_path, line, column, content }) => {
+      const filePath = path.resolve(file_path);
+      const client = await workspaceManager.getClient(filePath);
+      const uri = pathToUri(filePath);
+      await documentManager.ensureOpen(uri, client.getConnection(), content);
+
+      const lspPos = toLspPosition(line, column);
+      const result = await client.definition(uri, lspPos.line, lspPos.character);
+
+      const definitions = normalizeDefinitionResult(result, documentManager);
+
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ definitions }) }],
+      };
+    },
+  );
+}
+
+function normalizeDefinitionResult(
+  result: Location | Location[] | LocationLink[] | null | undefined,
+  docManager: DocumentManager,
+): Array<{ file_path: string; line: number; column: number; preview: string | null }> {
+  if (!result) return [];
+
+  // Single Location
+  if (!Array.isArray(result)) {
+    return [locationToEntry(result as Location, docManager)];
+  }
+
+  // Empty array
+  if (result.length === 0) return [];
+
+  // Discriminate: LocationLink has targetUri, Location has uri
+  const first = result[0];
+  if ('targetUri' in first) {
+    // LocationLink[]
+    return (result as LocationLink[]).map((link) => {
+      const filePath = uriToPath(link.targetUri);
+      const pos = fromLspPosition(link.targetSelectionRange.start);
+      const preview = getPreviewLine(filePath, pos.line, docManager);
+      return { file_path: filePath, line: pos.line, column: pos.column, preview };
+    });
+  }
+
+  // Location[]
+  return (result as Location[]).map((loc) => locationToEntry(loc, docManager));
+}
+
+function locationToEntry(
+  loc: Location,
+  docManager: DocumentManager,
+): { file_path: string; line: number; column: number; preview: string | null } {
+  const filePath = uriToPath(loc.uri);
+  const pos = fromLspPosition(loc.range.start);
+  const preview = getPreviewLine(filePath, pos.line, docManager);
+  return { file_path: filePath, line: pos.line, column: pos.column, preview };
+}

--- a/src/tools/hover.ts
+++ b/src/tools/hover.ts
@@ -1,0 +1,113 @@
+import path from 'node:path';
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Hover, MarkupContent, MarkedString } from 'vscode-languageserver-protocol';
+import type { WorkspaceManager } from '../workspace-manager.js';
+import type { DocumentManager } from '../document-manager.js';
+import { pathToUri, toLspPosition, fromLspPosition } from '../utils.js';
+
+export function registerHoverTool(
+  server: McpServer,
+  workspaceManager: WorkspaceManager,
+  documentManager: DocumentManager,
+): void {
+  server.registerTool(
+    'ts_hover',
+    {
+      description: 'Get hover/type information for a TypeScript/JavaScript symbol',
+      inputSchema: {
+        file_path: z.string().describe('Absolute path to the file'),
+        line: z.number().describe('Line number (1-indexed)'),
+        column: z.number().describe('Column number (1-indexed)'),
+        content: z.string().optional().describe('Optional file content override'),
+      },
+    },
+    async ({ file_path, line, column, content }) => {
+      const filePath = path.resolve(file_path);
+      const client = await workspaceManager.getClient(filePath);
+      const uri = pathToUri(filePath);
+      await documentManager.ensureOpen(uri, client.getConnection(), content);
+
+      const lspPos = toLspPosition(line, column);
+      const result = await client.hover(uri, lspPos.line, lspPos.character);
+
+      if (!result) {
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ hover: null }) }],
+        };
+      }
+
+      const hover = normalizeHoverResult(result);
+
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ hover }) }],
+      };
+    },
+  );
+}
+
+interface HoverResult {
+  contents: string;
+  language?: string;
+  range?: {
+    start: { line: number; column: number };
+    end: { line: number; column: number };
+  };
+}
+
+function normalizeHoverResult(hover: Hover): HoverResult {
+  const { contents, language } = extractContents(hover.contents);
+
+  const result: HoverResult = { contents };
+  if (language) result.language = language;
+
+  if (hover.range) {
+    result.range = {
+      start: fromLspPosition(hover.range.start),
+      end: fromLspPosition(hover.range.end),
+    };
+  }
+
+  return result;
+}
+
+function extractContents(
+  contents: MarkupContent | MarkedString | MarkedString[],
+): { contents: string; language?: string } {
+  // MarkupContent: { kind, value }
+  if (typeof contents === 'object' && 'kind' in contents) {
+    return { contents: (contents as MarkupContent).value };
+  }
+
+  // string (MarkedString)
+  if (typeof contents === 'string') {
+    return { contents };
+  }
+
+  // { language, value } (MarkedString object form)
+  if (typeof contents === 'object' && !Array.isArray(contents) && 'language' in contents) {
+    const ms = contents as { language: string; value: string };
+    return { contents: ms.value, language: ms.language };
+  }
+
+  // MarkedString[]
+  if (Array.isArray(contents)) {
+    const parts: string[] = [];
+    let language: string | undefined;
+    for (const item of contents) {
+      if (typeof item === 'string') {
+        parts.push(item);
+      } else {
+        parts.push(item.value);
+        if (!language && item.language) {
+          language = item.language;
+        }
+      }
+    }
+    const result: { contents: string; language?: string } = { contents: parts.join('\n') };
+    if (language) result.language = language;
+    return result;
+  }
+
+  return { contents: String(contents) };
+}

--- a/src/tools/references.ts
+++ b/src/tools/references.ts
@@ -1,0 +1,47 @@
+import path from 'node:path';
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { WorkspaceManager } from '../workspace-manager.js';
+import type { DocumentManager } from '../document-manager.js';
+import { pathToUri, uriToPath, toLspPosition, fromLspPosition, getPreviewLine } from '../utils.js';
+
+export function registerReferencesTool(
+  server: McpServer,
+  workspaceManager: WorkspaceManager,
+  documentManager: DocumentManager,
+): void {
+  server.registerTool(
+    'ts_references',
+    {
+      description: 'Find all references of a TypeScript/JavaScript symbol',
+      inputSchema: {
+        file_path: z.string().describe('Absolute path to the file'),
+        line: z.number().describe('Line number (1-indexed)'),
+        column: z.number().describe('Column number (1-indexed)'),
+        content: z.string().optional().describe('Optional file content override'),
+        include_declaration: z.boolean().optional().describe('Include the declaration in results (default: true)'),
+      },
+    },
+    async ({ file_path, line, column, content, include_declaration }) => {
+      const filePath = path.resolve(file_path);
+      const client = await workspaceManager.getClient(filePath);
+      const uri = pathToUri(filePath);
+      await documentManager.ensureOpen(uri, client.getConnection(), content);
+
+      const lspPos = toLspPosition(line, column);
+      const includeDecl = include_declaration !== undefined ? include_declaration : true;
+      const result = await client.references(uri, lspPos.line, lspPos.character, includeDecl);
+
+      const references = (result ?? []).map((loc) => {
+        const refPath = uriToPath(loc.uri);
+        const pos = fromLspPosition(loc.range.start);
+        const preview = getPreviewLine(refPath, pos.line, documentManager);
+        return { file_path: refPath, line: pos.line, column: pos.column, preview };
+      });
+
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ references }) }],
+      };
+    },
+  );
+}

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, '..');
+const fixtureRoot = path.resolve(__dirname, 'fixtures', 'sample-project');
+
+let client: Client;
+let transport: StdioClientTransport;
+
+describe('Smoke tests', () => {
+  beforeAll(async () => {
+    transport = new StdioClientTransport({
+      command: 'node',
+      args: [path.resolve(projectRoot, 'dist', 'index.js')],
+    });
+
+    client = new Client({ name: 'smoke-test', version: '1.0.0' });
+    await client.connect(transport);
+  }, 30000);
+
+  afterAll(async () => {
+    try {
+      await client.close();
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  it('ts_definition resolves greet import to utils.ts', async () => {
+    // Go-to-definition on the import specifier './utils.js' should resolve to utils.ts
+    // The string './utils.js' starts at column 29 on line 1
+    const indexFile = path.resolve(fixtureRoot, 'src', 'index.ts');
+    const result = await client.callTool({
+      name: 'ts_definition',
+      arguments: { file_path: indexFile, line: 1, column: 30 },
+    });
+
+    const parsed = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    expect(parsed.definitions).toBeDefined();
+    expect(parsed.definitions.length).toBeGreaterThanOrEqual(1);
+
+    // At least one definition should point to utils.ts
+    const hasUtilsDef = parsed.definitions.some(
+      (def: { file_path: string }) => def.file_path.includes('utils.ts'),
+    );
+    expect(hasUtilsDef).toBe(true);
+  }, 30000);
+
+  it('ts_references finds references to greet function', async () => {
+    const utilsFile = path.resolve(fixtureRoot, 'src', 'utils.ts');
+    const result = await client.callTool({
+      name: 'ts_references',
+      arguments: { file_path: utilsFile, line: 1, column: 17 },
+    });
+
+    const parsed = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    expect(parsed.references).toBeDefined();
+    expect(parsed.references.length).toBeGreaterThanOrEqual(1);
+  }, 30000);
+
+  it('ts_hover returns hover info for greet function', async () => {
+    const utilsFile = path.resolve(fixtureRoot, 'src', 'utils.ts');
+    const result = await client.callTool({
+      name: 'ts_hover',
+      arguments: { file_path: utilsFile, line: 1, column: 17 },
+    });
+
+    const parsed = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    expect(parsed.hover).toBeDefined();
+    expect(parsed.hover).not.toBeNull();
+    expect(parsed.hover.contents).toBeDefined();
+    expect(parsed.hover.contents.length).toBeGreaterThan(0);
+  }, 30000);
+});


### PR DESCRIPTION
## Summary
- Registers `ts_definition`, `ts_references`, and `ts_hover` as MCP tools using the SDK's `registerTool` API
- Wires `WorkspaceManager` + `DocumentManager` singletons in `src/index.ts` with graceful SIGINT/SIGTERM shutdown
- All positions are 1-indexed externally, converted to 0-indexed for LSP internally
- Normalizes all LSP result variants (Location, Location[], LocationLink[], MarkupContent, MarkedString)
- End-to-end smoke tests spawn the MCP server as a child process and exercise all three tools against the fixture project

## Sub-issues
- #9 MCP bootstrap
- #10 ts_definition
- #11 ts_references
- #12 ts_hover
- #13 Smoke test

## Test plan
- [x] `npm run build` — no errors
- [x] `npm test` — 40/40 tests pass (37 existing + 3 smoke)
- [x] Smoke test verifies ts_definition resolves `greet` import to `utils.ts`
- [x] Smoke test verifies ts_references finds references to `greet`
- [x] Smoke test verifies ts_hover returns type info

Closes #2, closes #9, closes #10, closes #11, closes #12, closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)