### PR TITLE
feat: Symbol Search and Project Polish

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -316,11 +316,12 @@ Each tool tested against the `tests/fixtures/sample-project/` — a small TS pro
 
 ## Verification Checklist
 
-- [ ] `npm run build` compiles without errors
-- [ ] Smoke test passes: initialize → tools/list → ts_definition → shutdown
-- [ ] Each tool returns 1-indexed positions and file paths (not URIs)
-- [ ] Each tool returns source preview lines
-- [ ] Unsaved buffer content is correctly synced to LSP
-- [ ] Server handles missing files gracefully (error, not crash)
+- [x] `npm run build` compiles without errors
+- [x] Smoke test passes: initialize → tools/list → ts_definition → shutdown
+- [x] Each tool returns 1-indexed positions and file paths (not URIs)
+- [x] Each tool returns source preview lines
+- [x] Unsaved buffer content is correctly synced to LSP
+- [x] Server handles missing files gracefully (error, not crash)
+- [x] `ts_symbols` works for file and workspace scope
 - [ ] Server works with Claude Code MCP configuration
 - [ ] Server works with Mistral Vibe MCP configuration

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 TypeScript MCP Language Server Protocol Bridge — exposes TypeScript semantic analysis as MCP tools for AI agents.
 
-**Status:** Core navigation tools implemented. `ts_definition`, `ts_references`, and `ts_hover` are registered as MCP tools and fully functional.
+**Status:** MVP complete. `ts_definition`, `ts_references`, `ts_hover`, and `ts_symbols` are registered as MCP tools and fully functional.
 
 ## Architecture
 
@@ -22,7 +22,7 @@ Agent <-> [stdio/MCP SDK] <-> MCP Server <-> LSP Client <-> [stdio] <-> typescri
 | `ts_definition` | Go to definition | Implemented |
 | `ts_references` | Find all references | Implemented |
 | `ts_hover` | Get type info and documentation | Implemented |
-| `ts_symbols` | Search symbols (Milestone 2) | Planned |
+| `ts_symbols` | Search symbols (file or workspace scope) | Implemented |
 
 ## Setup
 
@@ -47,6 +47,7 @@ src/
     definition.ts       # ts_definition MCP tool
     references.ts       # ts_references MCP tool
     hover.ts            # ts_hover MCP tool
+    symbols.ts          # ts_symbols MCP tool
 tests/
   lsp-client.test.ts
   workspace-manager.test.ts
@@ -56,6 +57,31 @@ tests/
   fixtures/
     sample-project/     # Test fixture with tsconfig + TS sources
 ```
+
+## MCP Configuration
+
+### Claude Code
+
+Add to `~/.claude/settings.json` or your project's `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "tsmcp-lsp": {
+      "command": "node",
+      "args": ["/path/to/tsmcp-LSP/dist/index.js"]
+    }
+  }
+}
+```
+
+### Generic MCP client (stdio transport)
+
+```bash
+node /path/to/tsmcp-LSP/dist/index.js
+```
+
+The server communicates over stdio using the MCP protocol. Any MCP-compatible client can connect by spawning the process and exchanging JSON-RPC messages on stdin/stdout.
 
 ## Design
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { DocumentManager } from './document-manager.js';
 import { registerDefinitionTool } from './tools/definition.js';
 import { registerReferencesTool } from './tools/references.js';
 import { registerHoverTool } from './tools/hover.js';
+import { registerSymbolsTool } from './tools/symbols.js';
 
 const server = new McpServer({
   name: 'tsmcp-lsp',
@@ -18,6 +19,7 @@ const documentManager = new DocumentManager();
 registerDefinitionTool(server, workspaceManager, documentManager);
 registerReferencesTool(server, workspaceManager, documentManager);
 registerHoverTool(server, workspaceManager, documentManager);
+registerSymbolsTool(server, workspaceManager, documentManager);
 
 // Graceful shutdown
 async function shutdown() {

--- a/src/tools/symbols.ts
+++ b/src/tools/symbols.ts
@@ -1,0 +1,183 @@
+import path from 'node:path';
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  SymbolKind,
+  type SymbolInformation,
+  type DocumentSymbol,
+  type WorkspaceSymbol,
+} from 'vscode-languageserver-protocol';
+import type { WorkspaceManager } from '../workspace-manager.js';
+import type { DocumentManager } from '../document-manager.js';
+import { pathToUri, uriToPath, fromLspPosition } from '../utils.js';
+
+const SYMBOL_KIND_NAMES: Record<number, string> = {
+  [SymbolKind.File]: 'file',
+  [SymbolKind.Module]: 'module',
+  [SymbolKind.Namespace]: 'namespace',
+  [SymbolKind.Package]: 'package',
+  [SymbolKind.Class]: 'class',
+  [SymbolKind.Method]: 'method',
+  [SymbolKind.Property]: 'property',
+  [SymbolKind.Field]: 'field',
+  [SymbolKind.Constructor]: 'constructor',
+  [SymbolKind.Enum]: 'enum',
+  [SymbolKind.Interface]: 'interface',
+  [SymbolKind.Function]: 'function',
+  [SymbolKind.Variable]: 'variable',
+  [SymbolKind.Constant]: 'constant',
+  [SymbolKind.String]: 'string',
+  [SymbolKind.Number]: 'number',
+  [SymbolKind.Boolean]: 'boolean',
+  [SymbolKind.Array]: 'array',
+  [SymbolKind.Object]: 'object',
+  [SymbolKind.Key]: 'key',
+  [SymbolKind.Null]: 'null',
+  [SymbolKind.EnumMember]: 'enum-member',
+  [SymbolKind.Struct]: 'struct',
+  [SymbolKind.Event]: 'event',
+  [SymbolKind.Operator]: 'operator',
+  [SymbolKind.TypeParameter]: 'type-parameter',
+};
+
+interface SymbolEntry {
+  name: string;
+  kind: string;
+  file_path: string;
+  line: number;
+  column: number;
+  container: string | null;
+}
+
+function symbolKindName(kind: SymbolKind): string {
+  return SYMBOL_KIND_NAMES[kind] ?? 'unknown';
+}
+
+function flattenDocumentSymbols(
+  symbols: DocumentSymbol[],
+  filePath: string,
+  container: string | null,
+): SymbolEntry[] {
+  const result: SymbolEntry[] = [];
+  for (const sym of symbols) {
+    const pos = fromLspPosition(sym.selectionRange.start);
+    result.push({
+      name: sym.name,
+      kind: symbolKindName(sym.kind),
+      file_path: filePath,
+      line: pos.line,
+      column: pos.column,
+      container,
+    });
+    if (sym.children && sym.children.length > 0) {
+      result.push(...flattenDocumentSymbols(sym.children, filePath, sym.name));
+    }
+  }
+  return result;
+}
+
+function isDocumentSymbolArray(
+  result: SymbolInformation[] | DocumentSymbol[],
+): result is DocumentSymbol[] {
+  return result.length > 0 && 'selectionRange' in result[0];
+}
+
+export function registerSymbolsTool(
+  server: McpServer,
+  workspaceManager: WorkspaceManager,
+  documentManager: DocumentManager,
+): void {
+  server.registerTool(
+    'ts_symbols',
+    {
+      description:
+        'Search for symbols in a file (document symbols) or across the workspace (workspace symbols)',
+      inputSchema: {
+        query: z.string().describe('Symbol name or prefix to search for'),
+        file_path: z
+          .string()
+          .describe(
+            'Absolute path to a file. For file scope, returns symbols in this file. For workspace scope, determines the workspace root to search.',
+          ),
+        scope: z
+          .enum(['file', 'workspace'])
+          .optional()
+          .describe('Search scope: "file" for document symbols, "workspace" for workspace-wide (default: "workspace")'),
+      },
+    },
+    async ({ query, file_path, scope }) => {
+      const filePath = path.resolve(file_path);
+      const client = await workspaceManager.getClient(filePath);
+      const uri = pathToUri(filePath);
+      const effectiveScope = scope ?? 'workspace';
+
+      let symbols: SymbolEntry[];
+
+      if (effectiveScope === 'file') {
+        await documentManager.ensureOpen(uri, client.getConnection());
+        const result = await client.documentSymbol(uri);
+        if (!result || result.length === 0) {
+          symbols = [];
+        } else if (isDocumentSymbolArray(result)) {
+          symbols = flattenDocumentSymbols(result, filePath, null);
+        } else {
+          // SymbolInformation[]
+          symbols = (result as SymbolInformation[]).map((sym) => ({
+            name: sym.name,
+            kind: symbolKindName(sym.kind),
+            file_path: sym.location ? uriToPath(sym.location.uri) : filePath,
+            line: sym.location ? fromLspPosition(sym.location.range.start).line : 1,
+            column: sym.location ? fromLspPosition(sym.location.range.start).column : 1,
+            container: sym.containerName ?? null,
+          }));
+        }
+
+        // Filter by query (case-insensitive prefix match)
+        if (query) {
+          const lowerQuery = query.toLowerCase();
+          symbols = symbols.filter((s) => s.name.toLowerCase().includes(lowerQuery));
+        }
+      } else {
+        // workspace scope
+        const result = await client.workspaceSymbol(query);
+        if (!result || result.length === 0) {
+          symbols = [];
+        } else {
+          symbols = (result as (SymbolInformation | WorkspaceSymbol)[]).map((sym) => {
+            const loc = sym.location;
+            let symFilePath: string;
+            let line: number;
+            let column: number;
+
+            if ('uri' in loc) {
+              // SymbolInformation location: { uri, range }
+              symFilePath = uriToPath(loc.uri);
+              const range = (loc as { uri: string; range: { start: { line: number; character: number } } }).range;
+              const pos = fromLspPosition(range.start);
+              line = pos.line;
+              column = pos.column;
+            } else {
+              // WorkspaceSymbol location: { uri } only (no range)
+              symFilePath = uriToPath((loc as { uri: string }).uri);
+              line = 1;
+              column = 1;
+            }
+
+            return {
+              name: sym.name,
+              kind: symbolKindName(sym.kind),
+              file_path: symFilePath,
+              line,
+              column,
+              container: sym.containerName ?? null,
+            };
+          });
+        }
+      }
+
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ symbols }) }],
+      };
+    },
+  );
+}

--- a/src/tools/symbols.ts
+++ b/src/tools/symbols.ts
@@ -132,7 +132,7 @@ export function registerSymbolsTool(
           }));
         }
 
-        // Filter by query (case-insensitive prefix match)
+        // Filter by query (case-insensitive substring match)
         if (query) {
           const lowerQuery = query.toLowerCase();
           symbols = symbols.filter((s) => s.name.toLowerCase().includes(lowerQuery));
@@ -149,7 +149,7 @@ export function registerSymbolsTool(
             let line: number;
             let column: number;
 
-            if ('uri' in loc) {
+            if ('range' in loc) {
               // SymbolInformation location: { uri, range }
               symFilePath = uriToPath(loc.uri);
               const range = (loc as { uri: string; range: { start: { line: number; character: number } } }).range;

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -75,4 +75,100 @@ describe('Smoke tests', () => {
     expect(parsed.hover.contents).toBeDefined();
     expect(parsed.hover.contents.length).toBeGreaterThan(0);
   }, 30000);
+
+  it('ts_symbols returns file-scope symbols from utils.ts', async () => {
+    const utilsFile = path.resolve(fixtureRoot, 'src', 'utils.ts');
+    const result = await client.callTool({
+      name: 'ts_symbols',
+      arguments: { query: '', file_path: utilsFile, scope: 'file' },
+    });
+
+    const parsed = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    expect(parsed.symbols).toBeDefined();
+    expect(parsed.symbols.length).toBeGreaterThanOrEqual(2);
+
+    const names = parsed.symbols.map((s: { name: string }) => s.name);
+    expect(names).toContain('greet');
+    expect(names).toContain('add');
+
+    // Verify symbol structure
+    const greetSym = parsed.symbols.find((s: { name: string }) => s.name === 'greet');
+    expect(greetSym.kind).toBe('function');
+    expect(greetSym.file_path).toContain('utils.ts');
+    expect(greetSym.line).toBe(1);
+    expect(typeof greetSym.column).toBe('number');
+  }, 30000);
+
+  it('ts_symbols filters file-scope symbols by query', async () => {
+    const utilsFile = path.resolve(fixtureRoot, 'src', 'utils.ts');
+    const result = await client.callTool({
+      name: 'ts_symbols',
+      arguments: { query: 'greet', file_path: utilsFile, scope: 'file' },
+    });
+
+    const parsed = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    expect(parsed.symbols).toBeDefined();
+    expect(parsed.symbols.length).toBe(1);
+    expect(parsed.symbols[0].name).toBe('greet');
+  }, 30000);
+
+  it('ts_symbols returns workspace-scope symbols', async () => {
+    const utilsFile = path.resolve(fixtureRoot, 'src', 'utils.ts');
+    const result = await client.callTool({
+      name: 'ts_symbols',
+      arguments: { query: 'greet', file_path: utilsFile, scope: 'workspace' },
+    });
+
+    const parsed = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    expect(parsed.symbols).toBeDefined();
+    expect(parsed.symbols.length).toBeGreaterThanOrEqual(1);
+
+    const greetSym = parsed.symbols.find((s: { name: string }) => s.name === 'greet');
+    expect(greetSym).toBeDefined();
+    expect(greetSym.kind).toBe('function');
+    expect(greetSym.file_path).toContain('utils.ts');
+    expect(greetSym.line).toBeGreaterThanOrEqual(1);
+  }, 30000);
+
+  it('ts_symbols defaults to workspace scope', async () => {
+    const utilsFile = path.resolve(fixtureRoot, 'src', 'utils.ts');
+    const result = await client.callTool({
+      name: 'ts_symbols',
+      arguments: { query: 'add', file_path: utilsFile },
+    });
+
+    const parsed = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    expect(parsed.symbols).toBeDefined();
+    expect(parsed.symbols.length).toBeGreaterThanOrEqual(1);
+
+    const addSym = parsed.symbols.find((s: { name: string }) => s.name === 'add');
+    expect(addSym).toBeDefined();
+  }, 30000);
+
+  it('ts_symbols returns empty array for no matches', async () => {
+    const utilsFile = path.resolve(fixtureRoot, 'src', 'utils.ts');
+    const result = await client.callTool({
+      name: 'ts_symbols',
+      arguments: { query: 'nonexistentsymbolxyz', file_path: utilsFile, scope: 'file' },
+    });
+
+    const parsed = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    expect(parsed.symbols).toBeDefined();
+    expect(parsed.symbols.length).toBe(0);
+  }, 30000);
+
+  it('ts_symbols uses absolute file paths and 1-indexed positions', async () => {
+    const utilsFile = path.resolve(fixtureRoot, 'src', 'utils.ts');
+    const result = await client.callTool({
+      name: 'ts_symbols',
+      arguments: { query: '', file_path: utilsFile, scope: 'file' },
+    });
+
+    const parsed = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    for (const sym of parsed.symbols) {
+      expect(path.isAbsolute(sym.file_path)).toBe(true);
+      expect(sym.line).toBeGreaterThanOrEqual(1);
+      expect(sym.column).toBeGreaterThanOrEqual(1);
+    }
+  }, 30000);
 });


### PR DESCRIPTION
## Summary

- Implement `ts_symbols` MCP tool with file and workspace scope (#14)
- Add smoke tests for symbol search covering both scopes, query filtering, empty results, and position formatting (#15)
- Update README with ts_symbols status, MCP configuration examples, and project structure (#16)
- Update verification checklist in implementation plan

Closes #3, closes #14, closes #15, closes #16

## Changes

- **`src/tools/symbols.ts`** — new tool supporting `scope: "file"` (LSP documentSymbol) and `scope: "workspace"` (LSP workspaceSymbol, default). Normalizes symbol kinds, flattens hierarchical document symbols, uses absolute paths and 1-indexed positions.
- **`src/index.ts`** — register `ts_symbols` tool
- **`tests/smoke.test.ts`** — 6 new end-to-end tests for ts_symbols
- **`README.md`** — updated status, tool table, project structure, added MCP config examples
- **`IMPLEMENTATION_PLAN.md`** — checked off completed verification items

## Test plan

- [x] `npm run build` compiles without errors
- [x] All 46 tests pass (14 utils + 10 doc-manager + 6 workspace + 7 lsp-client + 9 smoke)
- [x] ts_symbols file scope returns correct symbols from fixture
- [x] ts_symbols workspace scope finds symbols across workspace
- [x] Query filtering works (case-insensitive)
- [x] Empty results return `{ symbols: [] }`
- [x] All positions are 1-indexed, all paths are absolute

🤖 Generated with [Claude Code](https://claude.com/claude-code)