### PR TITLE
feat: add implementation + call hierarchy LSP operations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ import { registerDefinitionTool } from './tools/definition.js';
 import { registerReferencesTool } from './tools/references.js';
 import { registerHoverTool } from './tools/hover.js';
 import { registerSymbolsTool } from './tools/symbols.js';
+import { registerImplementationTool } from './tools/implementation.js';
+import { registerCallHierarchyTool } from './tools/call-hierarchy.js';
 
 const server = new McpServer({
   name: 'tsmcp-lsp',
@@ -20,6 +22,8 @@ registerDefinitionTool(server, workspaceManager, documentManager);
 registerReferencesTool(server, workspaceManager, documentManager);
 registerHoverTool(server, workspaceManager, documentManager);
 registerSymbolsTool(server, workspaceManager, documentManager);
+registerImplementationTool(server, workspaceManager, documentManager);
+registerCallHierarchyTool(server, workspaceManager, documentManager);
 
 // Graceful shutdown
 async function shutdown() {

--- a/src/lsp-client.ts
+++ b/src/lsp-client.ts
@@ -14,6 +14,10 @@ import {
   HoverRequest,
   DocumentSymbolRequest,
   WorkspaceSymbolRequest,
+  ImplementationRequest,
+  CallHierarchyPrepareRequest,
+  CallHierarchyIncomingCallsRequest,
+  CallHierarchyOutgoingCallsRequest,
   type InitializeParams,
   type Location,
   type Hover,
@@ -27,6 +31,9 @@ import {
   type DefinitionLink,
   type ProtocolConnection,
   type WorkspaceSymbol,
+  type CallHierarchyItem,
+  type CallHierarchyIncomingCall,
+  type CallHierarchyOutgoingCall,
 } from 'vscode-languageserver-protocol/node.js';
 import { pathToUri } from './utils.js';
 
@@ -104,6 +111,13 @@ export class LspClient {
           documentSymbol: {
             dynamicRegistration: false,
             hierarchicalDocumentSymbolSupport: true,
+          },
+          implementation: {
+            dynamicRegistration: false,
+            linkSupport: true,
+          },
+          callHierarchy: {
+            dynamicRegistration: false,
           },
         },
         workspace: {
@@ -218,6 +232,58 @@ export class LspClient {
     this.ensureInitialized();
     const params: WorkspaceSymbolParams = { query };
     return this.connection!.sendRequest(WorkspaceSymbolRequest.type, params);
+  }
+
+  /**
+   * Go to implementation.
+   */
+  async implementation(
+    uri: string,
+    line: number,
+    character: number,
+  ): Promise<Definition | DefinitionLink[] | null> {
+    this.ensureInitialized();
+    const params: TextDocumentPositionParams = {
+      textDocument: { uri },
+      position: { line, character },
+    };
+    return this.connection!.sendRequest(ImplementationRequest.type, params);
+  }
+
+  /**
+   * Prepare call hierarchy at position.
+   */
+  async prepareCallHierarchy(
+    uri: string,
+    line: number,
+    character: number,
+  ): Promise<CallHierarchyItem[] | null> {
+    this.ensureInitialized();
+    const params: TextDocumentPositionParams = {
+      textDocument: { uri },
+      position: { line, character },
+    };
+    return this.connection!.sendRequest(CallHierarchyPrepareRequest.type, params);
+  }
+
+  /**
+   * Get incoming calls for a call hierarchy item.
+   */
+  async callHierarchyIncomingCalls(
+    item: CallHierarchyItem,
+  ): Promise<CallHierarchyIncomingCall[] | null> {
+    this.ensureInitialized();
+    return this.connection!.sendRequest(CallHierarchyIncomingCallsRequest.type, { item });
+  }
+
+  /**
+   * Get outgoing calls for a call hierarchy item.
+   */
+  async callHierarchyOutgoingCalls(
+    item: CallHierarchyItem,
+  ): Promise<CallHierarchyOutgoingCall[] | null> {
+    this.ensureInitialized();
+    return this.connection!.sendRequest(CallHierarchyOutgoingCallsRequest.type, { item });
   }
 
   /**

--- a/src/tools/call-hierarchy.ts
+++ b/src/tools/call-hierarchy.ts
@@ -12,7 +12,7 @@ interface CallEntry {
   line: number;
   column: number;
   preview: string | null;
-  call_sites: Array<{ line: number; column: number }>;
+  call_sites: Array<{ file_path: string; line: number; column: number }>;
 }
 
 export function registerCallHierarchyTool(
@@ -55,7 +55,7 @@ export function registerCallHierarchyTool(
           allCalls.push(...formatIncomingCalls(incoming, documentManager));
         } else {
           const outgoing = await client.callHierarchyOutgoingCalls(item);
-          allCalls.push(...formatOutgoingCalls(outgoing, documentManager));
+          allCalls.push(...formatOutgoingCalls(outgoing, item, documentManager));
         }
       }
 
@@ -66,8 +66,11 @@ export function registerCallHierarchyTool(
   );
 }
 
-function rangeToCallSites(ranges: Range[]): Array<{ line: number; column: number }> {
-  return ranges.map((r) => fromLspPosition(r.start));
+function rangeToCallSites(ranges: Range[], filePath: string): Array<{ file_path: string; line: number; column: number }> {
+  return ranges.map((r) => {
+    const pos = fromLspPosition(r.start);
+    return { file_path: filePath, line: pos.line, column: pos.column };
+  });
 }
 
 function formatIncomingCalls(
@@ -77,18 +80,22 @@ function formatIncomingCalls(
   if (!calls) return [];
   return calls.map((call) => {
     const entry = formatCallHierarchyItem(call.from, docManager);
-    return { ...entry, call_sites: rangeToCallSites(call.fromRanges) };
+    // fromRanges are in the caller's file (call.from)
+    return { ...entry, call_sites: rangeToCallSites(call.fromRanges, entry.file_path) };
   });
 }
 
 function formatOutgoingCalls(
   calls: CallHierarchyOutgoingCall[] | null,
+  sourceItem: CallHierarchyItem,
   docManager: DocumentManager,
 ): CallEntry[] {
   if (!calls) return [];
+  // fromRanges for outgoing calls are in the source item's file, not in call.to's file
+  const sourceFilePath = uriToPath(sourceItem.uri);
   return calls.map((call) => {
     const entry = formatCallHierarchyItem(call.to, docManager);
-    return { ...entry, call_sites: rangeToCallSites(call.fromRanges) };
+    return { ...entry, call_sites: rangeToCallSites(call.fromRanges, sourceFilePath) };
   });
 }
 

--- a/src/tools/call-hierarchy.ts
+++ b/src/tools/call-hierarchy.ts
@@ -1,10 +1,19 @@
 import path from 'node:path';
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { CallHierarchyItem, CallHierarchyIncomingCall, CallHierarchyOutgoingCall } from 'vscode-languageserver-protocol';
+import type { CallHierarchyItem, CallHierarchyIncomingCall, CallHierarchyOutgoingCall, Range } from 'vscode-languageserver-protocol';
 import type { WorkspaceManager } from '../workspace-manager.js';
 import type { DocumentManager } from '../document-manager.js';
 import { pathToUri, uriToPath, toLspPosition, fromLspPosition, getPreviewLine } from '../utils.js';
+
+interface CallEntry {
+  name: string;
+  file_path: string;
+  line: number;
+  column: number;
+  preview: string | null;
+  call_sites: Array<{ line: number; column: number }>;
+}
 
 export function registerCallHierarchyTool(
   server: McpServer,
@@ -38,38 +47,49 @@ export function registerCallHierarchyTool(
         };
       }
 
-      const item = items[0];
-      let calls: Array<{ name: string; file_path: string; line: number; column: number; preview: string | null }>;
-
-      if (direction === 'incoming') {
-        const incoming = await client.callHierarchyIncomingCalls(item);
-        calls = formatIncomingCalls(incoming, documentManager);
-      } else {
-        const outgoing = await client.callHierarchyOutgoingCalls(item);
-        calls = formatOutgoingCalls(outgoing, documentManager);
+      // Process all prepared items, not just the first one
+      const allCalls: CallEntry[] = [];
+      for (const item of items) {
+        if (direction === 'incoming') {
+          const incoming = await client.callHierarchyIncomingCalls(item);
+          allCalls.push(...formatIncomingCalls(incoming, documentManager));
+        } else {
+          const outgoing = await client.callHierarchyOutgoingCalls(item);
+          allCalls.push(...formatOutgoingCalls(outgoing, documentManager));
+        }
       }
 
       return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ calls }) }],
+        content: [{ type: 'text' as const, text: JSON.stringify({ calls: allCalls }) }],
       };
     },
   );
 }
 
+function rangeToCallSites(ranges: Range[]): Array<{ line: number; column: number }> {
+  return ranges.map((r) => fromLspPosition(r.start));
+}
+
 function formatIncomingCalls(
   calls: CallHierarchyIncomingCall[] | null,
   docManager: DocumentManager,
-): Array<{ name: string; file_path: string; line: number; column: number; preview: string | null }> {
+): CallEntry[] {
   if (!calls) return [];
-  return calls.map((call) => formatCallHierarchyItem(call.from, docManager));
+  return calls.map((call) => {
+    const entry = formatCallHierarchyItem(call.from, docManager);
+    return { ...entry, call_sites: rangeToCallSites(call.fromRanges) };
+  });
 }
 
 function formatOutgoingCalls(
   calls: CallHierarchyOutgoingCall[] | null,
   docManager: DocumentManager,
-): Array<{ name: string; file_path: string; line: number; column: number; preview: string | null }> {
+): CallEntry[] {
   if (!calls) return [];
-  return calls.map((call) => formatCallHierarchyItem(call.to, docManager));
+  return calls.map((call) => {
+    const entry = formatCallHierarchyItem(call.to, docManager);
+    return { ...entry, call_sites: rangeToCallSites(call.fromRanges) };
+  });
 }
 
 function formatCallHierarchyItem(

--- a/src/tools/call-hierarchy.ts
+++ b/src/tools/call-hierarchy.ts
@@ -1,0 +1,83 @@
+import path from 'node:path';
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallHierarchyItem, CallHierarchyIncomingCall, CallHierarchyOutgoingCall } from 'vscode-languageserver-protocol';
+import type { WorkspaceManager } from '../workspace-manager.js';
+import type { DocumentManager } from '../document-manager.js';
+import { pathToUri, uriToPath, toLspPosition, fromLspPosition, getPreviewLine } from '../utils.js';
+
+export function registerCallHierarchyTool(
+  server: McpServer,
+  workspaceManager: WorkspaceManager,
+  documentManager: DocumentManager,
+): void {
+  server.registerTool(
+    'ts_call_hierarchy',
+    {
+      description: 'Find incoming or outgoing calls for a TypeScript/JavaScript function',
+      inputSchema: {
+        file_path: z.string().describe('Absolute path to the file'),
+        line: z.number().describe('Line number (1-indexed)'),
+        column: z.number().describe('Column number (1-indexed)'),
+        direction: z.enum(['incoming', 'outgoing']).describe('Direction: "incoming" finds callers, "outgoing" finds callees'),
+        content: z.string().optional().describe('Optional file content override'),
+      },
+    },
+    async ({ file_path, line, column, direction, content }) => {
+      const filePath = path.resolve(file_path);
+      const client = await workspaceManager.getClient(filePath);
+      const uri = pathToUri(filePath);
+      await documentManager.ensureOpen(uri, client.getConnection(), content);
+
+      const lspPos = toLspPosition(line, column);
+      const items = await client.prepareCallHierarchy(uri, lspPos.line, lspPos.character);
+
+      if (!items || items.length === 0) {
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ calls: [] }) }],
+        };
+      }
+
+      const item = items[0];
+      let calls: Array<{ name: string; file_path: string; line: number; column: number; preview: string | null }>;
+
+      if (direction === 'incoming') {
+        const incoming = await client.callHierarchyIncomingCalls(item);
+        calls = formatIncomingCalls(incoming, documentManager);
+      } else {
+        const outgoing = await client.callHierarchyOutgoingCalls(item);
+        calls = formatOutgoingCalls(outgoing, documentManager);
+      }
+
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ calls }) }],
+      };
+    },
+  );
+}
+
+function formatIncomingCalls(
+  calls: CallHierarchyIncomingCall[] | null,
+  docManager: DocumentManager,
+): Array<{ name: string; file_path: string; line: number; column: number; preview: string | null }> {
+  if (!calls) return [];
+  return calls.map((call) => formatCallHierarchyItem(call.from, docManager));
+}
+
+function formatOutgoingCalls(
+  calls: CallHierarchyOutgoingCall[] | null,
+  docManager: DocumentManager,
+): Array<{ name: string; file_path: string; line: number; column: number; preview: string | null }> {
+  if (!calls) return [];
+  return calls.map((call) => formatCallHierarchyItem(call.to, docManager));
+}
+
+function formatCallHierarchyItem(
+  item: CallHierarchyItem,
+  docManager: DocumentManager,
+): { name: string; file_path: string; line: number; column: number; preview: string | null } {
+  const filePath = uriToPath(item.uri);
+  const pos = fromLspPosition(item.selectionRange.start);
+  const preview = getPreviewLine(filePath, pos.line, docManager);
+  return { name: item.name, file_path: filePath, line: pos.line, column: pos.column, preview };
+}

--- a/src/tools/implementation.ts
+++ b/src/tools/implementation.ts
@@ -1,0 +1,76 @@
+import path from 'node:path';
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Location, LocationLink } from 'vscode-languageserver-protocol';
+import type { WorkspaceManager } from '../workspace-manager.js';
+import type { DocumentManager } from '../document-manager.js';
+import { pathToUri, uriToPath, toLspPosition, fromLspPosition, getPreviewLine } from '../utils.js';
+
+export function registerImplementationTool(
+  server: McpServer,
+  workspaceManager: WorkspaceManager,
+  documentManager: DocumentManager,
+): void {
+  server.registerTool(
+    'ts_implementation',
+    {
+      description: 'Find concrete implementations of a TypeScript/JavaScript interface or abstract class',
+      inputSchema: {
+        file_path: z.string().describe('Absolute path to the file'),
+        line: z.number().describe('Line number (1-indexed)'),
+        column: z.number().describe('Column number (1-indexed)'),
+        content: z.string().optional().describe('Optional file content override'),
+      },
+    },
+    async ({ file_path, line, column, content }) => {
+      const filePath = path.resolve(file_path);
+      const client = await workspaceManager.getClient(filePath);
+      const uri = pathToUri(filePath);
+      await documentManager.ensureOpen(uri, client.getConnection(), content);
+
+      const lspPos = toLspPosition(line, column);
+      const result = await client.implementation(uri, lspPos.line, lspPos.character);
+
+      const implementations = normalizeImplementationResult(result, documentManager);
+
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ implementations }) }],
+      };
+    },
+  );
+}
+
+function normalizeImplementationResult(
+  result: Location | Location[] | LocationLink[] | null | undefined,
+  docManager: DocumentManager,
+): Array<{ file_path: string; line: number; column: number; preview: string | null }> {
+  if (!result) return [];
+
+  if (!Array.isArray(result)) {
+    return [locationToEntry(result as Location, docManager)];
+  }
+
+  if (result.length === 0) return [];
+
+  const first = result[0];
+  if ('targetUri' in first) {
+    return (result as LocationLink[]).map((link) => {
+      const filePath = uriToPath(link.targetUri);
+      const pos = fromLspPosition(link.targetSelectionRange.start);
+      const preview = getPreviewLine(filePath, pos.line, docManager);
+      return { file_path: filePath, line: pos.line, column: pos.column, preview };
+    });
+  }
+
+  return (result as Location[]).map((loc) => locationToEntry(loc, docManager));
+}
+
+function locationToEntry(
+  loc: Location,
+  docManager: DocumentManager,
+): { file_path: string; line: number; column: number; preview: string | null } {
+  const filePath = uriToPath(loc.uri);
+  const pos = fromLspPosition(loc.range.start);
+  const preview = getPreviewLine(filePath, pos.line, docManager);
+  return { file_path: filePath, line: pos.line, column: pos.column, preview };
+}

--- a/tests/fixtures/sample-project/src/interfaces.ts
+++ b/tests/fixtures/sample-project/src/interfaces.ts
@@ -1,0 +1,7 @@
+export interface Greeter {
+  greet(name: string): string;
+}
+
+export interface Calculator {
+  add(a: number, b: number): number;
+}

--- a/tests/fixtures/sample-project/src/services.ts
+++ b/tests/fixtures/sample-project/src/services.ts
@@ -1,0 +1,13 @@
+import { Greeter, Calculator } from './interfaces.js';
+
+export class FriendlyGreeter implements Greeter {
+  greet(name: string): string {
+    return `Hey there, ${name}!`;
+  }
+}
+
+export class SimpleCalculator implements Calculator {
+  add(a: number, b: number): number {
+    return a + b;
+  }
+}

--- a/tests/implementation-call-hierarchy.test.ts
+++ b/tests/implementation-call-hierarchy.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  DidOpenTextDocumentNotification,
+} from 'vscode-languageserver-protocol';
+import { LspClient } from '../src/lsp-client.js';
+import { pathToUri } from '../src/utils.js';
+import { readFileSync } from 'node:fs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixtureRoot = path.resolve(
+  __dirname,
+  'fixtures/sample-project',
+);
+
+describe('Implementation and Call Hierarchy', () => {
+  let client: LspClient;
+
+  beforeAll(async () => {
+    client = new LspClient(fixtureRoot);
+    await client.start();
+
+    const files = [
+      'src/utils.ts',
+      'src/index.ts',
+      'src/interfaces.ts',
+      'src/services.ts',
+    ];
+
+    const conn = client.getConnection();
+
+    for (const file of files) {
+      const filePath = path.join(fixtureRoot, file);
+      const content = readFileSync(filePath, 'utf-8');
+      conn.sendNotification(DidOpenTextDocumentNotification.type, {
+        textDocument: {
+          uri: pathToUri(filePath),
+          languageId: 'typescript',
+          version: 1,
+          text: content,
+        },
+      });
+    }
+
+    // Give the language server time to process files
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }, 30000);
+
+  afterAll(async () => {
+    await client.shutdown();
+  }, 10000);
+
+  describe('goToImplementation', () => {
+    it('should find implementations of an interface', async () => {
+      const interfacesUri = pathToUri(path.join(fixtureRoot, 'src/interfaces.ts'));
+      // "Greeter" interface at line 0, char 17 (0-indexed)
+      const result = await client.implementation(interfacesUri, 0, 17);
+      expect(result).not.toBeNull();
+      const results = Array.isArray(result) ? result : [result];
+      expect(results.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should return results for a concrete class method', async () => {
+      const servicesUri = pathToUri(path.join(fixtureRoot, 'src/services.ts'));
+      // "greet" method in FriendlyGreeter at line 3, char 2 (0-indexed)
+      const result = await client.implementation(servicesUri, 3, 2);
+      expect(result).not.toBeNull();
+    });
+  });
+
+  describe('prepareCallHierarchy', () => {
+    it('should return call hierarchy items for a function', async () => {
+      const utilsUri = pathToUri(path.join(fixtureRoot, 'src/utils.ts'));
+      // "greet" function at line 0, char 16 (0-indexed)
+      const items = await client.prepareCallHierarchy(utilsUri, 0, 16);
+      expect(items).not.toBeNull();
+      expect(items!.length).toBeGreaterThanOrEqual(1);
+      expect(items![0].name).toBe('greet');
+    });
+  });
+
+  describe('callHierarchyIncomingCalls', () => {
+    it('should find callers of a function', async () => {
+      const utilsUri = pathToUri(path.join(fixtureRoot, 'src/utils.ts'));
+      // "greet" function at line 0, char 16 (0-indexed)
+      const items = await client.prepareCallHierarchy(utilsUri, 0, 16);
+      expect(items).not.toBeNull();
+      expect(items!.length).toBeGreaterThanOrEqual(1);
+
+      const incoming = await client.callHierarchyIncomingCalls(items![0]);
+      expect(incoming).not.toBeNull();
+      // index.ts calls greet()
+      expect(incoming!.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('callHierarchyOutgoingCalls', () => {
+    it('should find callees from a function scope', async () => {
+      const utilsUri = pathToUri(path.join(fixtureRoot, 'src/utils.ts'));
+      const items = await client.prepareCallHierarchy(utilsUri, 0, 16);
+      expect(items).not.toBeNull();
+
+      const outgoing = await client.callHierarchyOutgoingCalls(items![0]);
+      expect(outgoing).not.toBeNull();
+      // greet() is a simple function that doesn't call other functions
+      expect(Array.isArray(outgoing)).toBe(true);
+    });
+  });
+});

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -123,10 +123,9 @@ describe('Smoke tests', () => {
     expect(parsed.symbols).toBeDefined();
     expect(parsed.symbols.length).toBeGreaterThanOrEqual(1);
 
-    const greetSym = parsed.symbols.find((s: { name: string }) => s.name === 'greet');
+    const greetSym = parsed.symbols.find((s: { name: string; file_path: string }) => s.name === 'greet' && s.file_path.includes('utils.ts'));
     expect(greetSym).toBeDefined();
     expect(greetSym.kind).toBe('function');
-    expect(greetSym.file_path).toContain('utils.ts');
     expect(greetSym.line).toBeGreaterThanOrEqual(1);
   }, 30000);
 


### PR DESCRIPTION
## Summary

- Add `ts_implementation` tool for `textDocument/implementation` (go to concrete implementations of interfaces/abstract classes)
- Add `ts_call_hierarchy` tool for `textDocument/prepareCallHierarchy`, `callHierarchy/incomingCalls`, and `callHierarchy/outgoingCalls`
- Update `LspClient` with new methods and LSP capabilities for implementation and call hierarchy
- Add integration tests for all new operations with interface/class test fixtures

Closes #31, Closes #26, Closes #27, Closes #28

## Test plan

- [x] All 59 tests pass (8 test files)
- [x] `goToImplementation` finds concrete class implementing an interface
- [x] `prepareCallHierarchy` returns call hierarchy items for functions
- [x] `callHierarchyIncomingCalls` finds callers of a function
- [x] `callHierarchyOutgoingCalls` returns outgoing calls
- [x] Type-checks clean (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)